### PR TITLE
Change buffer flushing condition and summarize rule

### DIFF
--- a/api/services.py
+++ b/api/services.py
@@ -4,8 +4,9 @@ from sqlalchemy.orm import Session
 from bootstrap.deps import deps
 from service.duration import DurationService
 from service.heartbeat import HeartbeatService
-from service.user import UserService
 from service.setting import SettingService
+from service.summary import SummaryService
+from service.user import UserService
 
 
 def get_heartbeat_service(db: Session = Depends(deps.get_db)) -> HeartbeatService:
@@ -19,5 +20,10 @@ def get_duration_service(db: Session = Depends(deps.get_db)) -> DurationService:
 def get_user_service(db: Session = Depends(deps.get_db)) -> UserService:
     return UserService(db)
 
-def get_setting_service(db: Session = Depends(deps.get_db))->SettingService:
+
+def get_setting_service(db: Session = Depends(deps.get_db)) -> SettingService:
     return SettingService(db)
+
+
+def get_summary_service(db: Session = Depends(deps.get_db)) -> SummaryService:
+    return SummaryService(db)

--- a/api/summary.py
+++ b/api/summary.py
@@ -1,0 +1,35 @@
+from fastapi import APIRouter, Depends, Query
+
+from api.services import get_summary_service
+from schemas.summary import ListAgentRequest, ListDomainRequest, ListPathRequest
+from service.summary import SummaryService
+from service.user import UserService
+
+router = APIRouter(prefix="/settings", tags=["users"])
+
+
+@router.post("/domain")
+def list_domain(
+    request: ListDomainRequest,
+    summary_service: SummaryService = Depends(get_summary_service),
+    user_id: str = Query(...),
+):
+    return summary_service.list_domain(user_id, request.offset, request.limit)
+
+
+@router.post("/path")
+def get_path_usage(
+    request: ListPathRequest,
+    summary_service: SummaryService = Depends(get_summary_service),
+    user_id: str = Query(...),
+):
+    return summary_service.get_path(user_id, request.domain)
+
+
+@router.post("/agent")
+def get_agent_usage(
+    request: ListAgentRequest,
+    summary_service: SummaryService = Depends(get_summary_service),
+    user_id: str = Query(...),
+):
+    return summary_service.get_agent(user_id, request.domain)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,14 @@ services:
       POSTGRES_PASSWORD: postgres
     volumes:
       - ./.volume/postgresql:/var/lib/postgresql/data/
-
+  rabbitmq:
+    image: rabbitmq:management
+    ports:
+        - 5672:5672
+        - 15672:15672
+    volumes:
+        - ~/.volume/rabbitmq/data/:/var/lib/rabbitmq/
+        - ~/.volume/rabbitmq/log/:/var/log/rabbitmq
   # backend:
   #   build: .
   #   profiles: [production]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,15 @@ services:
     volumes:
         - ~/.volume/rabbitmq/data/:/var/lib/rabbitmq/
         - ~/.volume/rabbitmq/log/:/var/log/rabbitmq
+  etl:
+    build: .
+    context: ./etl
+    restart: unless-stopped
+    volumes:
+      - ./etl/:/usr/etl/
+    depends_on:
+      - db
+      - rabbitmq
   # backend:
   #   build: .
   #   profiles: [production]

--- a/etl/Cargo.lock
+++ b/etl/Cargo.lock
@@ -796,7 +796,9 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "futures",
+ "itertools 0.12.1",
  "lapin",
+ "lazy_static",
  "lockable",
  "opentelemetry",
  "opentelemetry-otlp",

--- a/etl/Cargo.toml
+++ b/etl/Cargo.toml
@@ -24,6 +24,8 @@ serde = {version= "1.0.197",features = ["derive"]}
 serde_json = "1.0.115"
 futures = "0.3.30"
 lockable = "0.0.8"
+itertools = "0.12.1"
+lazy_static = "1.4.0"
 
 [dependencies.tracing]
 version = "0.1.40"

--- a/etl/src/constant.rs
+++ b/etl/src/constant.rs
@@ -1,9 +1,13 @@
 use chrono::TimeDelta;
+use std::env::var;
 
-pub static SQL_URL: &str = "postgres://postgres:password@localhost:5432/postgres";
-pub static RABBITMQ_URL: &str = "amqp://guest:guest@localhost:5672/%2f";
+// postgres://postgres:admin@localhost:5432/postgres
+lazy_static::lazy_static! {
+    pub static ref SQL_URL: String = var("SQL_URL").unwrap_or("postgres://postgres:postgres@localhost:5432/postgres".to_string());
+    pub static ref RABBITMQ_URL: String = var("RABBITMQ_URL").unwrap_or("amqp://guest:guest@localhost:5672/%2f".to_string());
+    pub static ref RABBITMQ_QUEUE: String = var("RABBITMQ_QUEUE").unwrap_or("focus_summary_IN".to_string());
+}
 
-pub static RABBITMQ_QUEUE: &str = "focus_summary_IN";
 pub static BUFFER_MAX_LENGTH: usize = 1000;
 pub static BUFFER_MAX_TIME: TimeDelta = TimeDelta::minutes(10);
 

--- a/etl/src/constant.rs
+++ b/etl/src/constant.rs
@@ -11,4 +11,6 @@ lazy_static::lazy_static! {
 pub static BUFFER_MAX_LENGTH: usize = 1000;
 pub static BUFFER_MAX_TIME: TimeDelta = TimeDelta::minutes(10);
 
+pub const HEARTBEAT_THRESHOLD: TimeDelta = TimeDelta::minutes(2);
+
 pub type Time = chrono::DateTime<chrono::FixedOffset>;

--- a/etl/src/constant.rs
+++ b/etl/src/constant.rs
@@ -1,7 +1,6 @@
 use chrono::TimeDelta;
 use std::env::var;
 
-// postgres://postgres:admin@localhost:5432/postgres
 lazy_static::lazy_static! {
     pub static ref SQL_URL: String = var("SQL_URL").unwrap_or("postgres://postgres:postgres@localhost:5432/postgres".to_string());
     pub static ref RABBITMQ_URL: String = var("RABBITMQ_URL").unwrap_or("amqp://guest:guest@localhost:5672/%2f".to_string());

--- a/etl/src/logger.rs
+++ b/etl/src/logger.rs
@@ -1,0 +1,126 @@
+use std::error::Error;
+
+use opentelemetry::global;
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::{
+    metrics::{
+        reader::{DefaultAggregationSelector, DefaultTemporalitySelector, MetricReader},
+        MeterProvider, PeriodicReader,
+    },
+    runtime,
+    trace::{BatchConfig, RandomIdGenerator, Sampler, Tracer},
+    Resource,
+};
+use opentelemetry_semantic_conventions::{
+    resource::{DEPLOYMENT_ENVIRONMENT, SERVICE_NAME, SERVICE_VERSION},
+    SCHEMA_URL,
+};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+pub static PACKAGE_NAME: &str = "mdoj-backend";
+
+fn resource() -> Resource {
+    Resource::from_schema_url(
+        [
+            KeyValue::new(SERVICE_NAME, PACKAGE_NAME),
+            KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
+            #[cfg(debug_assertions)]
+            KeyValue::new(DEPLOYMENT_ENVIRONMENT, "development"),
+            #[cfg(not(debug_assertions))]
+            KeyValue::new(DEPLOYMENT_ENVIRONMENT, "production"),
+        ],
+        SCHEMA_URL,
+    )
+}
+
+// Construct MeterProvider for MetricsLayer
+fn init_meter_provider(reader: impl MetricReader) -> MeterProvider {
+    let meter_provider = MeterProvider::builder()
+        .with_resource(resource())
+        .with_reader(reader)
+        .build();
+
+    global::set_meter_provider(meter_provider.clone());
+
+    meter_provider
+}
+
+// Construct Tracer for OpenTelemetryLayer
+fn init_tracer(endpoint: &str) -> Result<Tracer, Box<dyn Error>> {
+    Ok(opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_trace_config(
+            opentelemetry_sdk::trace::Config::default()
+                // Customize sampling strategy
+                .with_sampler(Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(
+                    1.0,
+                ))))
+                // If export trace to AWS X-Ray, you can use XrayIdGenerator
+                .with_id_generator(RandomIdGenerator::default())
+                .with_resource(resource()),
+        )
+        .with_batch_config(BatchConfig::default())
+        .with_exporter(
+            opentelemetry_otlp::new_exporter()
+                .tonic()
+                .with_endpoint(endpoint),
+        )
+        .install_batch(runtime::Tokio)?)
+}
+
+// Initialize tracing-subscriber and return OtelGuard for opentelemetry-related termination processing
+fn init_tracing_subscriber() -> Result<OtelGuard, Box<dyn Error>> {
+    let exporter = opentelemetry_otlp::new_exporter()
+        .tonic()
+        .build_metrics_exporter(
+            Box::new(DefaultAggregationSelector::new()),
+            Box::new(DefaultTemporalitySelector::new()),
+        )
+        .unwrap();
+    let meter_provider = init_meter_provider(
+        PeriodicReader::builder(exporter, runtime::Tokio)
+            .with_interval(std::time::Duration::from_secs(30))
+            .build(),
+    );
+
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    Ok(OtelGuard { meter_provider })
+}
+
+pub struct OtelGuard {
+    pub meter_provider: MeterProvider,
+}
+
+impl Drop for OtelGuard {
+    fn drop(&mut self) {
+        if let Err(err) = self.meter_provider.shutdown() {
+            eprintln!("Error: {:?}", err);
+        }
+        opentelemetry::global::shutdown_tracer_provider();
+    }
+}
+
+fn init_panic_hook() {
+    std::panic::set_hook(Box::new(|panic| {
+        if let Some(location) = panic.location() {
+            tracing::error!(
+                message = %panic,
+                panic.file = location.file(),
+                panic.line = location.line(),
+                panic.column = location.column(),
+            );
+        } else {
+            tracing::error!(message = %panic);
+        }
+    }));
+}
+
+pub fn init() {
+    init_panic_hook();
+
+    init_tracing_subscriber().unwrap();
+}

--- a/etl/src/main.rs
+++ b/etl/src/main.rs
@@ -8,5 +8,7 @@ mod server;
 #[tokio::main]
 async fn main() {
     logger::init();
+    tracing::info!("Starting server...");
     Server::new().await.unwrap().attach().await.unwrap();
+    tracing::info!("Exit");
 }

--- a/etl/src/main.rs
+++ b/etl/src/main.rs
@@ -1,11 +1,12 @@
 use server::Server;
 
-pub mod constant;
-pub mod process;
-pub mod server;
+mod constant;
+mod logger;
+mod process;
+mod server;
 
 #[tokio::main]
 async fn main() {
-    // FIXME: add logger
+    logger::init();
     Server::new().await.unwrap().attach().await.unwrap();
 }

--- a/etl/src/main.rs
+++ b/etl/src/main.rs
@@ -11,4 +11,5 @@ async fn main() {
     tracing::info!("Starting server...");
     Server::new().await.unwrap().attach().await.unwrap();
     tracing::info!("Exit");
+    // 1970-01-01 00:00:00 +00:00
 }

--- a/etl/src/main.rs
+++ b/etl/src/main.rs
@@ -1,7 +1,11 @@
+use server::Server;
+
 pub mod constant;
 pub mod process;
 pub mod server;
 
-fn main() {
-    println!("Hello, world!");
+#[tokio::main]
+async fn main() {
+    // FIXME: add logger
+    Server::new().await.unwrap().attach().await.unwrap();
 }

--- a/etl/src/process/entity/summary_item.rs
+++ b/etl/src/process/entity/summary_item.rs
@@ -9,6 +9,8 @@ pub struct Model {
     #[sea_orm(column_name = "type")]
     pub kind: i32,
     pub total: i64,
+    #[sea_orm(column_type = "Text")]
+    pub key: String,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/etl/src/process/entity/summary_item.rs
+++ b/etl/src/process/entity/summary_item.rs
@@ -7,10 +7,21 @@ pub struct Model {
     pub id: Uuid,
     pub summary_id: Uuid,
     #[sea_orm(column_name = "type")]
-    pub kind: i32,
+    pub kind: RecordKind,
     pub total: i64,
     #[sea_orm(column_type = "Text")]
     pub key: String,
+}
+
+#[derive(Clone, Debug, PartialEq, EnumIter, DeriveActiveEnum, Eq)]
+#[sea_orm(rs_type = "i32", db_type = "Integer")]
+pub enum RecordKind {
+    #[sea_orm(num_value = 0)]
+    Domain,
+    #[sea_orm(num_value = 1)]
+    Path,
+    #[sea_orm(num_value = 2)]
+    UserAgent,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/etl/src/process/mod.rs
+++ b/etl/src/process/mod.rs
@@ -4,7 +4,6 @@ mod trie;
 mod upload;
 
 pub use payload::BeatBuffers;
-pub use payload::Beatbuffer;
 pub use payload::Heartbeats;
 
 #[derive(thiserror::Error, Debug)]

--- a/etl/src/process/payload.rs
+++ b/etl/src/process/payload.rs
@@ -33,7 +33,6 @@ pub struct Heartbeat {
 pub struct Heartbeats {
     pub trace_id: u64,
     pub user_id: Uuid,
-    user_agent: String,
     list: Vec<Heartbeat>,
 }
 

--- a/etl/src/process/payload.rs
+++ b/etl/src/process/payload.rs
@@ -24,7 +24,7 @@ pub struct Heartbeat {
 #[derive(Deserialize, Serialize)]
 pub struct Heartbeats {
     pub trace_id: u64,
-    user_id: Uuid,
+    pub user_id: Uuid,
     user_agent: String,
     list: Vec<Heartbeat>,
 }
@@ -107,6 +107,17 @@ impl BeatBuffers {
         match entry.value().unwrap().is_full() {
             true => Some(entry.remove().unwrap()),
             false => None,
+        }
+    }
+    pub async fn get_full(&self, uuid: Uuid) -> Option<Beatbuffer> {
+        let mut entry = self
+            .0
+            .async_lock(uuid, AsyncLimit::no_limit())
+            .await
+            .unwrap();
+        match entry.value_mut() {
+            Some(beat) if beat.is_full() => entry.remove(),
+            _ => None,
         }
     }
     /// force flush all the beatbuffer in the hashmap

--- a/etl/src/process/trie.rs
+++ b/etl/src/process/trie.rs
@@ -3,18 +3,18 @@
 use std::{collections::BTreeMap, ops::Deref};
 
 #[derive(Default)]
-pub struct Tree {
-    root: Node,
+pub struct Tree<V: Default> {
+    root: Node<V>,
 }
 
-impl Tree {
-    pub fn insert(&mut self, s: &str) {
-        self.root.occur += 1;
+impl<V: Default> Tree<V> {
+    pub fn insert(&mut self, s: &str, mut f: impl FnMut(&mut V)) {
+        f(&mut self.root.data);
 
         let mut cur = &mut self.root;
         for i in s.chars() {
             cur = cur.add_child(i);
-            cur.occur += 1;
+            f(&mut cur.data);
         }
         cur.leaf = true;
     }
@@ -29,11 +29,21 @@ impl Tree {
     //         self.insert(&prefix);
     //     }
     // }
-    pub fn iter(&self) -> TreeIter {
+    // pub fn from_iter<I: IntoIterator<Item = String>>(
+    //     iter: I,
+    //     mut f: impl FnMut(&mut V, &str),
+    // ) -> Self {
+    //     let mut tree = Tree::default();
+    //     for i in iter {
+    //         // tree.insert(&i, f);
+    //     }
+    //     tree
+    // }
+    pub fn into_iter(self) -> TreeIter<V> {
         let mut stack = Vec::new();
 
-        for (i, child) in self.root.children.iter() {
-            stack.push((child.deref(), *i, 0));
+        for (i, child) in self.root.children.into_iter() {
+            stack.push((child, i, 0));
         }
 
         TreeIter {
@@ -43,33 +53,24 @@ impl Tree {
     }
 }
 
-impl FromIterator<String> for Tree {
-    fn from_iter<I: IntoIterator<Item = String>>(iter: I) -> Self {
-        let mut tree = Tree::default();
-        for i in iter {
-            tree.insert(&i);
-        }
-        tree
-    }
-}
-
-pub struct TreeIter<'a> {
+pub struct TreeIter<V: Default> {
     prefix: String,
-    stack: Vec<(&'a Node, char, usize)>,
+    stack: Vec<(Box<Node<V>>, char, usize)>,
 }
 
-impl Iterator for TreeIter<'_> {
-    type Item = (usize, String);
+impl<V: Default> Iterator for TreeIter<V> {
+    type Item = (V, String);
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some((node, c, depth)) = self.stack.pop() {
             self.prefix.truncate(depth);
             self.prefix.push(c);
-            for (i, child) in node.children.iter() {
-                self.stack.push((node, *i, depth + 1));
-                if child.leaf {
-                    return Some((child.occur, self.prefix.clone()));
-                }
+            let data = (node.data, self.prefix.clone());
+            for (i, child) in node.children.into_iter() {
+                self.stack.push((child, i, depth + 1));
+            }
+            if node.leaf {
+                return Some(data);
             }
         }
         None
@@ -77,16 +78,47 @@ impl Iterator for TreeIter<'_> {
 }
 
 #[derive(Default)]
-struct Node {
-    children: BTreeMap<char, Box<Node>>,
-    occur: usize,
+struct Node<V: Default> {
+    children: BTreeMap<char, Box<Node<V>>>,
+    data: V,
     leaf: bool,
 }
 
-impl Node {
+impl<V: Default> Node<V> {
     fn add_child(&mut self, i: char) -> &mut Self {
         self.children
             .entry(i)
             .or_insert_with(|| Box::new(Node::default()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn trie_iter() {
+        let mut tree = Tree::<i32>::default();
+        tree.insert("hello", |x| *x += 1);
+        tree.insert("world", |x| *x += 1);
+        assert_eq!(
+            [(1_i32, "world".to_string()), (1_i32, "hello".to_string())],
+            *tree.into_iter().collect::<Vec<_>>()
+        );
+    }
+    #[test]
+    fn test_not_dfs() {
+        let mut tree = Tree::<i32>::default();
+        tree.insert("hello", |x| *x += 1);
+        tree.insert("helloaaa", |x| *x += 1);
+        tree.insert("helloaaabb", |x| *x += 1);
+        assert_eq!(
+            [
+                (3_i32, "hello".to_string()),
+                (2_i32, "helloaaa".to_string()),
+                (1_i32, "helloaaabb".to_string())
+            ],
+            *tree.into_iter().collect::<Vec<_>>()
+        );
     }
 }

--- a/etl/src/process/trie.rs
+++ b/etl/src/process/trie.rs
@@ -18,17 +18,17 @@ impl Tree {
         }
         cur.leaf = true;
     }
-    pub fn is_empty(&self) -> bool {
-        self.root.occur == 0
-    }
-    pub fn len(&self) -> usize {
-        self.root.occur
-    }
-    pub fn extend(&mut self, other: impl Iterator<Item = String>) {
-        for prefix in other {
-            self.insert(&prefix);
-        }
-    }
+    // pub fn is_empty(&self) -> bool {
+    //     self.root.occur == 0
+    // }
+    // pub fn len(&self) -> usize {
+    //     self.root.occur
+    // }
+    // pub fn extend(&mut self, other: impl Iterator<Item = String>) {
+    //     for prefix in other {
+    //         self.insert(&prefix);
+    //     }
+    // }
     pub fn iter(&self) -> TreeIter {
         let mut stack = Vec::new();
 

--- a/etl/src/process/trie.rs
+++ b/etl/src/process/trie.rs
@@ -1,6 +1,6 @@
 //! prefix tree
 
-use std::{collections::BTreeMap, ops::Deref};
+use std::collections::BTreeMap;
 
 #[derive(Default)]
 pub struct Tree<V: Default> {
@@ -59,13 +59,13 @@ pub struct TreeIter<V: Default> {
 }
 
 impl<V: Default> Iterator for TreeIter<V> {
-    type Item = (V, String);
+    type Item = (String, V);
 
     fn next(&mut self) -> Option<Self::Item> {
         while let Some((node, c, depth)) = self.stack.pop() {
             self.prefix.truncate(depth);
             self.prefix.push(c);
-            let data = (node.data, self.prefix.clone());
+            let data = (self.prefix.clone(), node.data);
             for (i, child) in node.children.into_iter() {
                 self.stack.push((child, i, depth + 1));
             }
@@ -102,7 +102,7 @@ mod test {
         tree.insert("hello", |x| *x += 1);
         tree.insert("world", |x| *x += 1);
         assert_eq!(
-            [(1_i32, "world".to_string()), (1_i32, "hello".to_string())],
+            [("world".to_string(), 1_i32), ("hello".to_string(), 1_i32)],
             *tree.into_iter().collect::<Vec<_>>()
         );
     }
@@ -114,9 +114,9 @@ mod test {
         tree.insert("helloaaabb", |x| *x += 1);
         assert_eq!(
             [
-                (3_i32, "hello".to_string()),
-                (2_i32, "helloaaa".to_string()),
-                (1_i32, "helloaaabb".to_string())
+                ("hello".to_string(), 3_i32),
+                ("helloaaa".to_string(), 2_i32),
+                ("helloaaabb".to_string(), 1_i32)
             ],
             *tree.into_iter().collect::<Vec<_>>()
         );

--- a/etl/src/process/upload.rs
+++ b/etl/src/process/upload.rs
@@ -8,19 +8,21 @@ impl super::payload::Beatbuffer {
     ) -> Result<(), Error> {
         use crate::process::entity::*;
         use sea_orm::*;
-        let (summary, tree) = self.into_payload();
+        for (summary, tree) in self.into_payloads() {
+            let summary = summary.insert(db.as_ref()).await?;
 
-        let summary = summary.insert(db.as_ref()).await?;
-
-        for (occur, path) in tree.iter() {
-            summary_item::ActiveModel {
-                summary_id: ActiveValue::Set(summary.id),
-                kind: ActiveValue::Set(todo!() as i32),
-                total: ActiveValue::Set(occur as i64),
-                ..Default::default()
-            };
+            for (occur, path) in tree.iter() {
+                summary_item::ActiveModel {
+                    summary_id: ActiveValue::Set(summary.id),
+                    kind: ActiveValue::Set(1 as i32), // FIXME: change it
+                    total: ActiveValue::Set(occur as i64),
+                    key: ActiveValue::Set(path),
+                    ..Default::default()
+                }
+                .insert(db.as_ref())
+                .await?;
+            }
         }
-
         Ok(())
     }
 }

--- a/etl/src/process/upload.rs
+++ b/etl/src/process/upload.rs
@@ -1,40 +1,71 @@
-use crate::constant::HEARTBEAT_THRESHOLD;
-
-use super::Error;
-use itertools::Itertools;
+use super::{
+    entity::{summary, summary_item},
+    Error,
+};
+use crate::{
+    constant::{Time, HEARTBEAT_THRESHOLD},
+    process::entity::summary_item::RecordKind,
+};
 use sea_orm::*;
+
+fn get_time_range(times: impl Iterator<Item = Time>) -> i64 {
+    let mut total = 0;
+    let mut times = times.collect::<Vec<_>>();
+    times.sort();
+    times.windows(2).for_each(|win| {
+        let delta = (win[1] - win[0]).abs();
+        if delta < HEARTBEAT_THRESHOLD {
+            total += delta.num_seconds() as i64;
+        }
+    });
+    total
+}
+
+struct SummaryWrapper<'a>(summary::Model, &'a DatabaseConnection);
+
+impl<'a> SummaryWrapper<'a> {
+    pub async fn insert_item(
+        &self,
+        kind: RecordKind,
+        times: impl Iterator<Item = Time>,
+        key: String,
+    ) -> Result<summary_item::Model, Error> {
+        let model = summary_item::ActiveModel {
+            summary_id: ActiveValue::Set(self.0.id),
+            kind: ActiveValue::Set(kind),
+            total: ActiveValue::Set(get_time_range(times)),
+            key: ActiveValue::Set(key),
+            ..Default::default()
+        }
+        .insert(self.1)
+        .await?;
+
+        Ok(model)
+    }
+}
 
 impl super::payload::Beatbuffer {
     pub async fn upload(
         self,
         db: impl AsRef<DatabaseConnection> + Send + 'static,
     ) -> Result<(), Error> {
-        use crate::process::entity::*;
-        use sea_orm::*;
-        for (summary, tree) in self.into_payloads() {
-            let summary = summary.insert(db.as_ref()).await?;
+        let (summary, tree) = self.clone().into_payloads();
+        let summary = summary.insert(db.as_ref()).await?;
+        let summary = SummaryWrapper(summary, db.as_ref());
 
-            for (mut times, path) in tree.into_iter() {
-                let mut total = 0;
-                times.sort();
-                times.windows(2).for_each(|win| {
-                    let delta = (win[1] - win[0]).abs();
-                    if delta < HEARTBEAT_THRESHOLD {
-                        total += delta.num_seconds() as i64;
-                    }
-                });
-
-                summary_item::ActiveModel {
-                    summary_id: ActiveValue::Set(summary.id),
-                    kind: ActiveValue::Set(1 as i32), // FIXME: change it
-                    total: ActiveValue::Set(total as i64),
-                    key: ActiveValue::Set(path),
-                    ..Default::default()
+        macro_rules! insert {
+            ($elements:expr, $kind:ident) => {
+                for (path, times) in $elements {
+                    summary
+                        .insert_item(RecordKind::$kind, times.into_iter(), path)
+                        .await?;
                 }
-                .insert(db.as_ref())
-                .await?;
-            }
+            };
         }
+        insert!(tree.into_iter(), Path);
+        insert!(self.clone().into_domains(), Domain);
+        insert!(self.into_agents(), UserAgent);
+
         Ok(())
     }
 }

--- a/etl/src/process/upload.rs
+++ b/etl/src/process/upload.rs
@@ -1,4 +1,7 @@
+use crate::constant::HEARTBEAT_THRESHOLD;
+
 use super::Error;
+use itertools::Itertools;
 use sea_orm::*;
 
 impl super::payload::Beatbuffer {
@@ -11,11 +14,20 @@ impl super::payload::Beatbuffer {
         for (summary, tree) in self.into_payloads() {
             let summary = summary.insert(db.as_ref()).await?;
 
-            for (occur, path) in tree.iter() {
+            for (mut times, path) in tree.into_iter() {
+                let mut total = 0;
+                times.sort();
+                times.windows(2).for_each(|win| {
+                    let delta = (win[1] - win[0]).abs();
+                    if delta < HEARTBEAT_THRESHOLD {
+                        total += delta.num_seconds() as i64;
+                    }
+                });
+
                 summary_item::ActiveModel {
                     summary_id: ActiveValue::Set(summary.id),
                     kind: ActiveValue::Set(1 as i32), // FIXME: change it
-                    total: ActiveValue::Set(occur as i64),
+                    total: ActiveValue::Set(total as i64),
                     key: ActiveValue::Set(path),
                     ..Default::default()
                 }

--- a/etl/src/server.rs
+++ b/etl/src/server.rs
@@ -95,7 +95,7 @@ impl Server {
     }
     pub async fn attach(self) -> Result<(), Error> {
         let self_ = Arc::new(self);
-        tokio::spawn(async move { slient_err!(self_.heartbeat().await) });
+        self_.heartbeat().await?;
         Ok(())
     }
 }

--- a/etl/src/server.rs
+++ b/etl/src/server.rs
@@ -34,7 +34,7 @@ impl Server {
         let conn = Connection::connect(&RABBITMQ_URL, ConnectionProperties::default()).await?;
 
         let channel = conn.create_channel().await?;
-        let db = Arc::new(Database::connect(SQL_URL).await?);
+        let db = Arc::new(Database::connect(&*SQL_URL).await?);
 
         Ok(Server {
             channel,
@@ -47,7 +47,7 @@ impl Server {
         let mut consumer = self
             .channel
             .basic_consume(
-                RABBITMQ_QUEUE,
+                &*RABBITMQ_QUEUE,
                 format!("consumer-{}", serial).as_str(),
                 options::BasicConsumeOptions::default(),
                 types::FieldTable::default(),

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,3 +1,5 @@
 from .heartbeat import *  # noqa
 from .user import *  # noqa
 from .setting import * # noqa
+from .summary import *  # noqa
+from .summary_item import *  # noqa

--- a/models/summary.py
+++ b/models/summary.py
@@ -1,0 +1,17 @@
+from uuid import uuid4
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+from .user import User
+
+
+class Summary(Base):
+    __tablename__ = "summary"
+    id: Mapped[str] = mapped_column(primary_key=True, index=True, default=uuid4().hex)
+    user_id: Mapped[str] = mapped_column(ForeignKey(User.id), index=True)
+    from_time: Mapped[datetime] = mapped_column(index=True)
+    to_time: Mapped[datetime] = mapped_column(index=True)
+

--- a/models/summary_item.py
+++ b/models/summary_item.py
@@ -1,0 +1,15 @@
+from uuid import uuid4
+
+from sqlalchemy import DateTime, ForeignKey, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+from .user import User
+
+class SummaryItem(Base):
+    __tablename__ = "summary_item"
+    id: Mapped[str] = mapped_column(primary_key=True, index=True, default=uuid4().hex)
+    summary_id: Mapped[str] = mapped_column(ForeignKey("summary.id"), index=True)
+    type: Mapped[int] = mapped_column(index=True)
+    total: Mapped[int] = mapped_column(index=True)
+    key: Mapped[str] = mapped_column(index=True)

--- a/schemas/__init__.py
+++ b/schemas/__init__.py
@@ -1,3 +1,6 @@
 from .heartbeat import *  # noqa
 from .user import *  # noqa
 from .duration import *  # noqa
+from .setting import * 
+from .summary_item import *
+from .summary import *

--- a/schemas/setting.py
+++ b/schemas/setting.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict
 
+
 class Setting(BaseModel):
     user_id: Optional[str]
     raw: Optional[str]
@@ -9,15 +10,16 @@ class Setting(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
+
 class UpdateSettingRequest(BaseModel):
     rev: int
     raw: str
 
     model_config = ConfigDict(from_attributes=True)
 
+
 class CreateSettingRequest(BaseModel):
     rev: int
     raw: str
 
     model_config = ConfigDict(from_attributes=True)
-

--- a/schemas/summary.py
+++ b/schemas/summary.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class Summary(BaseModel):
+    id: Optional[str]
+    user_id: Optional[str]
+    from_time: Optional[datetime]
+    to_time: Optional[datetime]
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ListDomainRequest(BaseModel):
+    offset: int
+    limit: int
+
+
+class ListPathRequest(BaseModel):
+    domain: str
+
+
+class ListAgentRequest(BaseModel):
+    domain: str

--- a/schemas/summary_item.py
+++ b/schemas/summary_item.py
@@ -1,0 +1,14 @@
+from typing import Optional
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+class SummaryItem(BaseModel):
+    id: Optional[str]
+    summary_id: Optional[str]
+    type: Optional[int]
+    total: Optional[int]
+    key: Optional[str]
+    
+    model_config = ConfigDict(from_attributes=True)
+

--- a/service/heartbeat.py
+++ b/service/heartbeat.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Dict, List, TypeVar
 
 from fastapi import status
-from sqlalchemy import func, or_
+from sqlalchemy import distinct, func, or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import InstrumentedAttribute
@@ -176,11 +176,9 @@ class HeartbeatService:
 
     # def get_entity_set_by_user(self, entity_type: int, user_id: str) -> List[str]:
     #     # Assuming GetEntityColumn is a function that returns the name of the column to filter on based on the entity type
-    #     entity_column = get_entity_column(
-    #         entity_type
-    #     )  # You need to implement this function
+    #     entity_column = "id"  # You need to implement this function
     #     results = (
-    #         self.db_session.query(distinct(getattr(models.Heartbeat, entity_column)))
+    #         self.db_session.query(distinct(models.Heartbeat.id))
     #         .filter_by(user_id=user_id)
     #         .all()
     #     )

--- a/service/summary.py
+++ b/service/summary.py
@@ -1,0 +1,60 @@
+from sqlalchemy import distinct, func
+from sqlalchemy.orm import Session
+
+import models as models
+import schemas as schemas
+from models import Summary, SummaryItem
+
+
+class SummaryService:
+    db_session: Session = None
+
+    def __init__(self, db_session: Session):
+        self.db_session = db_session
+
+    def list_domain(self, user_id: str, offset: int, limit: int) -> list[str]:
+        query = (
+            self.db_session.query(distinct(SummaryItem.key))
+            .join(Summary, Summary.id == SummaryItem.summary_id)
+            .filter(Summary.user_id == user_id, SummaryItem.type == 0)
+            .order_by(Summary.time.desc())
+            .offset(offset)
+            .limit(limit)
+        )
+
+        list = [row.domain for row in query.all()]
+        return list
+
+    def get_path(self, user_id: str, domain: str) -> list[dict]:
+        # duplicated code
+        summary_subquery = (
+            self.db_session.query([Summary.id, Summary.user_id])
+            .filter(Summary.user_id == user_id)
+            .join(SummaryItem, Summary.id == SummaryItem.summary_id)
+            .filter(SummaryItem.key == domain, SummaryItem.type == 0)
+        )
+        items = self.db_session.query(SummaryItem, func.count(SummaryItem.key)).filter(
+            SummaryItem.type == 1, SummaryItem.id.in_(summary_subquery)
+        )
+        result = {}
+        for x in items:
+            result[x[0]] = x[1]
+
+        return result
+
+    def get_agent(self, user_id: str, domain: str) -> list[dict]:
+        # duplicated code
+        summary_subquery = (
+            self.db_session.query([Summary.id, Summary.user_id])
+            .filter(Summary.user_id == user_id)
+            .join(SummaryItem, Summary.id == SummaryItem.summary_id)
+            .filter(SummaryItem.key == domain, SummaryItem.type == 0)
+        )
+        items = self.db_session.query(SummaryItem, func.count(SummaryItem.key)).filter(
+            SummaryItem.type == 2, SummaryItem.id.in_(summary_subquery)
+        )
+        result = {}
+        for x in items:
+            result[x[0]] = x[1]
+
+        return result


### PR DESCRIPTION

1. Group split iterator by `browser`, `category`, `entity`.

```rust
pub(super) fn into_payloads(self) -> impl Iterator<Item = (summary::ActiveModel, Tree)> {
    let mut result = Vec::new();
    for (_, beats) in self
        .beats
        .into_iter()
        .group_by(|x| (x.browser.clone(), x.category.clone(), x.entity.clone()))
        .into_iter()
    {
        let tree = Tree::from_iter(beats.map(|x| x.pathline));
        let summary = summary::ActiveModel {
            from_time: ActiveValue::Set(self.start.naive_local().time()),
            to_time: ActiveValue::Set(self.end.naive_local().time()),
            ..Default::default()
        };
        result.push((summary, tree));
    }
    result.into_iter()
}
```

2. Iterate over trie, collect different kind of path.

```rust
for (summary, tree) in self.into_payloads() {
    let summary = summary.insert(db.as_ref()).await?;

    for (occur, path) in tree.iter() {
        summary_item::ActiveModel {
            summary_id: ActiveValue::Set(summary.id),
            kind: ActiveValue::Set(1 as i32), // FIXME: change it
            total: ActiveValue::Set(occur as i64),
            key: ActiveValue::Set(path),
            ..Default::default()
        }
        .insert(db.as_ref())
        .await?;
    }
}
```